### PR TITLE
reStructuredText section heading support and better markdown Atx-Style header regex

### DIFF
--- a/lib/ctags.coffee
+++ b/lib/ctags.coffee
@@ -42,10 +42,14 @@ langdef =
     {re: /^[ \t]*<([a-zA-Z]+)[ \t]*.*>/, id: '%1', kind: 'Function'}
   ]
   Markdown: [
-    {re: /^####+[ \t]*([^#]+)/, id: '___# %1', kind: 'Contents'}
-    {re: /^###[ \t]*([^#]+)/, id: '__#%1', kind: 'Contents'}
-    {re: /^##[ \t]*([^#]+)/, id: '_# %1', kind: 'Contents'}
-    {re: /^#[ \t]*([^#]+)/, id: '# %1', kind: 'Contents'}
+    {re: /^#{1}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '# %1', kind: 'Outlines'}
+    {re: /^#{2}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '_# %1', kind: 'Outlines'}
+    {re: /^#{3}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '__# %1', kind: 'Outlines'}
+    {re: /^#{4}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '___# %1', kind: 'Outlines'}
+    {re: /^#{5}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '____# %1', kind: 'Outlines'}
+    {re: /^#{6}[ \t]*([^#]+)([ \t]*#+)?\n$/, multiline: true, id: '_____# %1', kind: 'Outlines'}
+    {re: /^(.*)\n=+(\n|$)/, multiline: true, id: '= %1', kind: 'Outlines'}
+    {re: /^(.*)\n-+(\n|$)/, multiline: true, id: '_- %1', kind: 'Outlines'}
   ]
   Json: [
     {re: /^[ \t]*"([^"]+)"[ \t]*\:/, id: '%1', kind: 'Field'}

--- a/lib/ctags.coffee
+++ b/lib/ctags.coffee
@@ -126,6 +126,9 @@ langdef =
     {re: /^[ \t]*(function|macro|abstract|type|typealias|immutable)[ \t]+([^ \t({[]+).*$/, id: '%2', kind: 'Function'}
     {re: /^[ \t]*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\)|\((\$)\))[ \t]*(\{.*\})?[ \t]*\([^#]*\)[ \t]*=([^=].*$|$)/, id: '%2%3%4', kind: 'Function'}
   ]
+  reStructuredText: [
+    {re: /^(.*)\n([!-/:-@[-`{-~])\2+$/, multiline: true, id: '%2%2%2 %1', kind: 'Outlines'}
+  ]
 langmap =
   '.coffee': langdef.CoffeeScript
   '.litcoffee': langdef.CoffeeScript
@@ -158,4 +161,5 @@ langmap =
   '.fountain': langdef.Fountain
   '.ftn': langdef.Fountain
   '.jl': langdef.Julia
+  '.rst': langdef.reStructuredText
 module.exports = {langdef: langdef, langmap: langmap}

--- a/lib/ctags.coffee
+++ b/lib/ctags.coffee
@@ -1,5 +1,5 @@
 # Created by ctags2coffee.coffee by processing .ctags
-langdef = 
+langdef =
   All: [
     {re: /#nav-mark:(.*)/i, id: '%1', kind: 'Markers'}
     {re: /#todo:(.*)/i, id: '%1', kind: 'Todo'}
@@ -39,7 +39,10 @@ langdef =
     {re: /^[ \t]*<([a-zA-Z]+)[ \t]*.*>/, id: '%1', kind: 'Function'}
   ]
   Markdown: [
-    {re: /^#+[ \t]*([^#]+)/, id: '%1', kind: 'Function'}
+    {re: /^####+[ \t]*([^#]+)/, id: '___# %1', kind: 'Contents'}
+    {re: /^###[ \t]*([^#]+)/, id: '__#%1', kind: 'Contents'}
+    {re: /^##[ \t]*([^#]+)/, id: '_# %1', kind: 'Contents'}
+    {re: /^#[ \t]*([^#]+)/, id: '# %1', kind: 'Contents'}
   ]
   Json: [
     {re: /^[ \t]*"([^"]+)"[ \t]*\:/, id: '%1', kind: 'Field'}
@@ -120,7 +123,7 @@ langdef =
     {re: /^[ \t]*(function|macro|abstract|type|typealias|immutable)[ \t]+([^ \t({[]+).*$/, id: '%2', kind: 'Function'}
     {re: /^[ \t]*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\)|\((\$)\))[ \t]*(\{.*\})?[ \t]*\([^#]*\)[ \t]*=([^=].*$|$)/, id: '%2%3%4', kind: 'Function'}
   ]
-langmap = 
+langmap =
   '.coffee': langdef.CoffeeScript
   '.litcoffee': langdef.CoffeeScript
   '.rb': langdef.Ruby

--- a/lib/nav-parser.coffee
+++ b/lib/nav-parser.coffee
@@ -103,7 +103,12 @@ class NavParser
         prevIndent = markerIndents.pop()
 
       for rule in activeRules
-        match = lineText.match(rule.re)
+        if rule.multiline == true && row < editor.getLineCount()
+          nextLineText = editor.lineTextForBufferRow(row + 1) 
+          lineText = lineText + '\n' + nextLineText
+          match = lineText.match(rule.re)
+        else
+          match = lineText.match(rule.re)
         if match
           parentIndent = -1
           markerIndents.push(indent) if indent > prevIndent
@@ -159,6 +164,8 @@ class NavParser
       reStr = reFields[1] #.replace(/\\/g, '\\\\')
       flag = 'i' if reFields[2]
       rule = {re: new RegExp(reStr, flag)}
+      if /\\n/.test(reFields[1])
+        rule.multiline = true
       parts.shift()
 
     for part in parts

--- a/lib/nav-view.coffee
+++ b/lib/nav-view.coffee
@@ -305,6 +305,8 @@ class NavView extends ResizableWidthView
       sort = @state[file].sort
     else
       sort = @settings.sort
+    if /\.(md|rst)$/.test(file)
+      sort = false
     if sort
       arrangedItems.sort (a,b)->
         key1 = (a.kind + '||' + a.label).toLowerCase()


### PR DESCRIPTION
pickup reStructuredText and markdown section heading.

reStructuredText require tow lines, header text and heading marker.
I add multiline flag, it indicate to concatenate with next line, then pass to regex match.

My Atx-Style header regex require blank line after Atx-Style header to distinguish from the super user shell prompt or comment in command line text.
