### PR TITLE
Use a copy of all-language rules instead of a ref

### DIFF
--- a/lib/nav-parser.coffee
+++ b/lib/nav-parser.coffee
@@ -53,7 +53,10 @@ class NavParser
     editorFile = editor.getPath()
     return unless editorFile  # happens with new file
 
-    activeRules = langdef.All || []
+    activeRules = langdef.All?.slice() || []  # MUST operate on a copy.
+    # Assigning without slice() in the line above caused additions to
+    # activeRules (below) to also be additions to langdef.All, which
+    # was definitely not desired.
     markerIndents = []    # indent chars to track parent/children
 
     updateRules = (newRule)->


### PR DESCRIPTION
The intent is to initialize activeRules to a copy of the all-language rules, not to (as happens now) use a reference, which (now) causes embedded and project rules to be added to the all-language rules.  Resolves #17 .