### PR TITLE
Fix issues oth0 19 and 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next
-* Merged @johnarwe PR#19 - fixed bugs (issues #19, #20)
+* Merged @johnarwe PR#23 - fixed bugs (issues #19, #20)
 
 ## 0.3.2
 * Fixed license file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Merged @johnarwe PR#19 - fixed bugs (issues #19, #20)
 
 ## 0.3.2
 * Fixed license file

--- a/lib/nav-panel.coffee
+++ b/lib/nav-panel.coffee
@@ -47,6 +47,7 @@ module.exports =
 
     @parser = new Parser()
     @navView = new NavView(state, settings, @parser)
+    @parser.constructorAsync(@navView)   # Read project-level files
 
     @subscriptions.add atom.config.onDidChange 'nav-panel-plus', (event) =>
       settings = event.newValue
@@ -62,6 +63,37 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace'
       , 'nav-panel-plus:changeSide': => @changePanelSide()
 
+    @subscriptions.add atom.workspace.observeTextEditors (editor)=>
+      # If an Atom project was closed with multiple files open, when Atom is restarted this
+      # event will fire "immediately" on each of the restored editors.
+      # This will also fire immediately when an existing file is opened, which might be after activate() is called,
+      # so we handle setting the view for the active window here rather than inside activate().
+      editorFile = editor.getPath() # Note: value === undefined for new file
+      activeEditor = atom.workspace.getActiveTextEditor()
+      if editor is activeEditor  # Calling setFile for others is pointless, since the parser assumes the active editor
+        if editorFile  # new-file buffers have no File object
+          @navView.setFile(editorFile)
+      # TODO: Refactor this into a common method; currently it is a copy of the code below -
+      # Panel also needs to be updated when text saved
+      return unless editor and editor.onDidSave
+      if !editor.ziOnEditorSave
+        editor.ziOnEditorSave = editor.onDidSave (event) =>
+          return unless @enabled
+          # With autosave, this gets called before onClick.
+          # We want click to be handled first
+          # setImmediate didn't work.
+          setTimeout =>
+            editorFile = editor.getPath()
+            @navView.updateFile(editorFile) if editorFile
+          , 200
+        @subscriptions.add editor.ziOnEditorSave
+
+        @subscriptions.add editor.onDidDestroy =>
+          @navView.closeFile(editorFile)
+
+    # onDidStopChangingActivePaneItem does NOT fire in some cases, like opening a project that
+    # has files open already (as recorded in the project's saved state).  From the Atom 1.18.0 doc, observeTextEditors
+    # *should* cover all the right cases.
     @subscriptions.add atom.workspace.onDidStopChangingActivePaneItem (paneItem)=>
       editor = atom.workspace.getActiveTextEditor()
       return @navView.hide() unless editor


### PR DESCRIPTION
1.  Change log: guessing at the request number that will be assigned for now, will update if wrong.
1.  nav-panel observeTextEditors is _mostly_ a copy of (existing) onDidStopChangingActivePaneItem.  The differences primarily stem from the former being passed an editor, vs the latter a pane item.
1.  nav-parser: splitting the constructor + redriving nav-view after the I/O completes solves the race condition when opening a file and project rules contribute markers.  Renaming parse() was simply for clarity, since it was not apparent in nav-view; the caller could deal with any editor as input, but the called routine would unconditionally create markers from the active editor.
1. nav-view changes are catching the request to refresh markers once project rules have been added, and fixing the base code's ability to productively act on any editor input despite what parse() was doing to/for it.
